### PR TITLE
Authenticate on form submit

### DIFF
--- a/Resources/Private/Templates/WebAuthnLoginForm.html
+++ b/Resources/Private/Templates/WebAuthnLoginForm.html
@@ -23,7 +23,7 @@
         </div>
         <div class="form-group" id="t3-webauthn-next-section">
             <button class="btn btn-block btn-login t3js-webauthn-next"
-                type="button"
+                type="submit"
                 id="t3-webauthn-next"
                 name="commandLI"
                 data-loading-text="<i class='fa fa-circle-o-notch fa-spin'></i> {f:translate(key: 'login.process')}"

--- a/Resources/Public/JavaScript/WebAuthnLogin.js
+++ b/Resources/Public/JavaScript/WebAuthnLogin.js
@@ -5,8 +5,13 @@ define(['jquery',], function ($) {
     }
 
     $(function () {
-        var $nextButton = $('#t3-webauthn-next');
-        $nextButton.on('click', function (event) {
+        const $loginForm = $('#typo3-login-form');
+        const $nextButton = $('#t3-webauthn-next');
+        let authenticated = false;
+        $loginForm.on('submit', function (event) {
+            if (authenticated) {
+                return;
+            }
             event.preventDefault();
             $nextButton.button('loading');
             var username = $('#t3-username').val();
@@ -41,6 +46,7 @@ define(['jquery',], function ($) {
                                 userHandle: data.response.userHandle ? arrayToBase64String(new Uint8Array(data.response.userHandle)) : null
                             }
                         };
+                        authenticated = true;
                         $('#t3-password').val(btoa(JSON.stringify(publicKeyCredential)));
                         $('#typo3-login-form').submit();
                     }, error => {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,8 @@
         "phpstan/phpstan": "^0.10",
         "saschaegerer/phpstan-typo3": "^0.10.1",
         "typo3/testing-framework": "^4",
-        "phpunit/phpunit": "^7"
+        "phpunit/phpunit": "^7",
+        "typo3/minimal": "^9.5.0"
     },
     "autoload": {
         "psr-4": {
@@ -52,7 +53,8 @@
         "typo3/cms": {
             "extension-key": "cvc_webauthn",
             "cms-package-dir": "{$vendor-dir}/typo3/cms",
-            "web-dir": ".Build/public"
+            "web-dir": ".Build/public",
+            "app-dir": ".Build"
         }
     }
 }


### PR DESCRIPTION
Hi there,
I just started to work on a similar extension when I stumbled across this one, so I thought I might as well have a look at this one first :)

I noticed that the login form does not actually start the webauthn flow on submit (after hitting enter) but only when the user actually hits the button. I modified the template and JS code to make sure the submit event is used instead.

I also installed typo3/minimal as a dev requirement to be able to use the TYPO3 install wizard for my dev environment.